### PR TITLE
Fix activerecord.errors.models translations being truncated by gem.

### DIFF
--- a/config/locales/lines.de.yml
+++ b/config/locales/lines.de.yml
@@ -62,5 +62,3 @@ de:
       lines/user:
         email: 'E-Mail'
         password: 'Passwort'
-    errors:
-      models:

--- a/config/locales/lines.en.yml
+++ b/config/locales/lines.en.yml
@@ -62,5 +62,3 @@ en:
       lines/user:
         email: 'E-Mail'
         password: 'Password'
-    errors:
-      models:


### PR DESCRIPTION
Having the following 'empty' translation sections from the lines-engine gem causes the corresponding translation sections in the actual application to be truncated, when the translations are loaded and merged.

```ruby
activerecord:
  errors:
    models:
```