### PR TITLE
fix No such middleware to insert before: ActionDispatch::Static

### DIFF
--- a/lib/lines/engine.rb
+++ b/lib/lines/engine.rb
@@ -34,6 +34,10 @@ module Lines
       end
     end
 
+    initializer "host helpers" do |app|
+      Lines::ApplicationController.helper app.helpers
+    end
+
     # Disable error wrapper around form fields
     config.action_view.field_error_proc = Proc.new { |html_tag, instance| 
       class_attr_index = html_tag.index 'class="'

--- a/lib/lines/engine.rb
+++ b/lib/lines/engine.rb
@@ -21,7 +21,7 @@ module Lines
 
     # Initializer to combine this engines static assets with the static assets of the hosting site.
     initializer "static assets" do |app|
-      app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public")
+      app.middleware.insert_after(::Rack::Runtime, ::ActionDispatch::Static, "#{root}/public")
     end
 
     initializer "lines.assets.precompile" do |app|


### PR DESCRIPTION
`ActionDispatch::Static` is not in the middleware chain when `serve_static_assets = false` (default)
This fixes: https://github.com/opoloo/lines-engine/issues/13