### PR TITLE
Fixed_picture_upload_for_Rails_5

### DIFF
--- a/app/models/lines/picture.rb
+++ b/app/models/lines/picture.rb
@@ -8,7 +8,7 @@ require 'carrierwave/orm/activerecord'
 module Lines  
   class Picture < Lines::ApplicationRecord
     # Associations    
-    belongs_to :article, touch: true
+    belongs_to :article, touch: true, optional: true
 
     # Mount carrierwave picture uploader
     mount_uploader :image, PictureUploader


### PR DESCRIPTION
The move to Rails 5 is causing a validation to be applied on the Lines::Picture model and preventing the Lines::PicturesController's create action to work.

Although I haven't checked if this breaks anything with other Rails versions, it does fix the issue on Rails 5.