### PR TITLE
Dashboard translation to render_navbar method on application_helper

### DIFF
--- a/app/helpers/lines/application_helper.rb
+++ b/app/helpers/lines/application_helper.rb
@@ -76,7 +76,7 @@ module Lines
             "<div class='submenu'>
               <div class='submenu-inner'>
                 <ul>
-                  <li>#{link_to("Dashboard", admin_articles_path)}</li>
+                  <li>#{link_to(t('lines.buttons.dashboard').html_safe, admin_articles_path)}</li>
                   <li>#{link_to(t('activerecord.models.lines/author', count: 2).html_safe, admin_authors_path)}</li>
                 </ul>
                 <ul>


### PR DESCRIPTION
Hi @thej,
How is it going? Building a Brazilian version of lines, I found there was no translation to the "Dashboard" word on rendering the navbar although the lines.buttons.dashboard is present on the lines.en.yml. Thus the translation for this "Dashboard" word can touch its respective locale file.
PS: I also have a Portuguese Brazilian file I could share with this repository. 
